### PR TITLE
fix an install bug in setup.py and add install command in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,3 +41,7 @@ meaning the `frame` parameter is always None.
         # do some gevent work after fork.
         work()
 
+
+## Install
+
+    pip install git+git://github.com/gwik/geventdaemon.git#egg=geventdaemon

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,14 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(name="geventdaemon",
       version="0.1dev",
       author="Antonin Amand",
       author_email="antonin.amand@gmail.com",
       description="gevent daemonizer",
-      package_dir = {'':'lib'},
-      packages=find_packages('lib'),
+      package_dir={'': 'lib'},
+      py_modules=['geventdaemon'],
       zip_safe=False,
       install_requires=[
           'gevent',
           'python-daemon',
-        ],
-    )
-
+      ])


### PR DESCRIPTION
This project is useful for me, thank you, but when I install it, I find a bug in setup.py, so I fix it.

This is the bug:

`find_packages('lib')` in setup.py return an empty list, so geventdaemon.py
will not be installed, fix by adding `py_modules` explicitly.
